### PR TITLE
fix: Upgrades Go version in Docker build image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
Updates the base image for the Docker build process. Addresses potential compatibility or build issues with an older Go runtime. Ensures the application leverages the latest stable Go version.